### PR TITLE
add error channel to Emitters

### DIFF
--- a/src/runtime/Runtime.ts
+++ b/src/runtime/Runtime.ts
@@ -101,7 +101,7 @@ export class Runtime {
     return this.inputs[symbol] ?? null;
   }
   bind_stream (stream: Output, target: Emitter) {
-    const sub = stream.watch(value => target.emit(value));
+    const sub = stream.watch(value => target.emit(value), err => target.emit_error(err));
     this.subscriptions.push(sub);
   }
 }


### PR DESCRIPTION
- watch method accepts an optional error listener
- new method for emitting errors to all error listeners
- errors within combined streams are individual
- errors are not stateful
- when binding streams to emitter ensure that errors are passed along